### PR TITLE
Production parameters

### DIFF
--- a/lcopt/bw2_export.py
+++ b/lcopt/bw2_export.py
@@ -38,7 +38,7 @@ class Bw2Exporter():
                 input_ids = [x['input'] for x in this_item['exchanges'] if x['type'] == 'technosphere']
                 production_index = get_names_index(db[production_id]['name'])
                 input_indexes = [get_names_index(db[x]['name']) for x in input_ids]
-                parameter_ids = ['p_{}_{}'.format(x, production_index) for x in input_indexes]
+                parameter_ids = ['n_p_{}_{}'.format(x, production_index) for x in input_indexes]
                 parameter_map_items = {(input_ids[n], k): parameter_ids[n] for n, x in enumerate(input_ids)}
                 #check = [self.modelInstance.params[x]['description'] for x in parameter_ids]
                 #print(check)

--- a/lcopt/bw2_import.py
+++ b/lcopt/bw2_import.py
@@ -33,20 +33,23 @@ def create_LcoptModel_from_BW2Package(import_filename):
     db = deepcopy(orig_db)
 
     temp_param_set = []
+    temp_production_param_set = []
 
     for k, v in db.items():
         exchanges = []
         production_amount = v['production amount']
 
         if production_amount != 1:
-            print("NOTE: Production amount for {} is not 1 unit ({}). Parameters for this process will be divided by {} to normalise to one unit of output".format(v['name'], production_amount, production_amount))
+            print("NOTE: Production amount for {} is not 1 unit ({})".format(v['name'], production_amount, production_amount))
+
+        temp_production_param_set.append({'of': v['name'], 'amount': production_amount})
 
         for e in v['exchanges']:
 
             exc_name = e.pop('name')
             exc_input = e.pop('input')
             exc_unit = unnormalise_unit(e.pop('unit'))
-            exc_amount = e.pop('amount') / production_amount
+            exc_amount = e.pop('amount')
             exc_type = e.pop('type')
 
             temp_param_set.append({'from': exc_name, 'to': v['name'], 'amount': exc_amount})
@@ -110,6 +113,11 @@ def create_LcoptModel_from_BW2Package(import_filename):
         if exc_from != exc_to:
             parameter_id = "p_{}_{}".format(exc_from, exc_to)
             param_set[parameter_id] = p['amount']
+
+    for p in temp_production_param_set:
+        exc_of = model.names.index(p['of'])
+        parameter_id = "p_{}_production".format(exc_of)
+        param_set[parameter_id] = p['amount']
 
     model.parameter_sets[db_name] = param_set
 

--- a/lcopt/static/css/function_box.css
+++ b/lcopt/static/css/function_box.css
@@ -12,26 +12,37 @@
 
 .item_biosphere{
 	background-color: #EFFFF7;
-
-
 }
+
+.item_production{
+	background-color: #8ca5ce;
+	padding-left:5px;
+	padding-right:5px;
+	border-radius: 2px;
+}
+
 .item_operator{
 	background-color: aliceblue;
+	border-radius: 2px;
 }
 
 .item_intermediate{
 	background-color: #FEFFEF;
+	border-radius: 2px;
 }
 
 .item_input{
 	background-color: #FAEFFF;
+	border-radius: 2px;
 }
 .item_number{
-	background-color: #ddd
+	background-color: #ddd;
+	border-radius: 2px;
 }
 
 .item_global{
 	background-color: #FEF9F9;
+	border-radius: 2px;
 }
 
 .selectize-control.plugin-clear_button .clearAll {

--- a/lcopt/static/js/function_box.js
+++ b/lcopt/static/js/function_box.js
@@ -37,9 +37,10 @@ function setUpSelectize(external_data){
 
 		icon_map = {
 			'input':'business',
-			'intermediate':'trending_flat',
+			'intermediate':'input',
 			'biosphere': 'local_florist',
 			'global':'language',
+			'production': 'forward'
 		},
 
 		name_map = {};
@@ -57,13 +58,13 @@ function setUpSelectize(external_data){
 		subsections = external_data[this_process].my_items;
 		for (var subsection in subsections){
 			subsection_name = subsections[subsection].name;
-			//console.log("\t" + subsection_name)
+			console.log("\t" + subsection_name)
 			items = subsections[subsection].my_items;
 			for (var item in items){
 				id = items[item].id;
 				name = items[item].name;
 				unit = items[item].unit;
-				console.log(unit);
+				console.log(subsection_name);
 
 				if(custom_type_map[subsection_name] == 'biosphere'){
 					option_text = "Emission of "+ name + " from " + to;
@@ -71,6 +72,9 @@ function setUpSelectize(external_data){
 				}else if (to_full == 'Global Parameters'){
 					option_text = name;
 					option_custom_type = 'global';
+				}else if(subsection_name == 'Production exchange (Output)'){
+					option_text = name;
+					option_custom_type = 'production';
 				}
 				else{
 					option_text = "Input of "+ name + " to " + to;

--- a/lcopt/static/js/treetest2.js
+++ b/lcopt/static/js/treetest2.js
@@ -349,7 +349,8 @@ function draw_tree(){
       total_impact = d.data.cum_impact + d.data.impact;
 
       //replace is for getting rif of trailing zeros
-      return  total_impact.toPrecision(2).replace(/\.?0*$/,'') + " " + method_unit; 
+      //return  total_impact.toPrecision(2).replace(/\.?0*$/,'') + " " + method_unit; 
+      return  total_impact.toPrecision(2) + " " + method_unit; 
     }
     });
     var wrap_height = nodeSizes.other[0],

--- a/lcopt/templates/create_functions.html
+++ b/lcopt/templates/create_functions.html
@@ -47,6 +47,10 @@
                         Global parameters :
                         <span class="item_global">&nbsp;Global parameter&nbsp;</span>
                     </p>
+                    <p>
+                        Production parameters :
+                        <span class="item_production">&nbsp;Output of X&nbsp;</span>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In response to #17 

This feature exposes the Brightway production exchange to LCOPT

It was a complicated fix, but in retrospect it provides a lot of calculation power.

There's now a new parameter dictionary in the `LcoptModel` class called `production_params` which is auto-populated during the `parameter_scan` function. Every output defaults to 1, but can now be edited.

All input parameters are now given an extra attribute `normalisation_parameter` which is the production parameter for that unit process.

During the analysis phase, the the new production parameters are evaluated in the same way as the input parameters. The production parameters are then used to create a normalised version of each parameter set, with id's in the format `n_p_{from}_{to}`, where `n_p_{from}_{to} = p_{from}_{to} / p_{to}_production`. The parameter hooks in the brightway export are changed to the normalised format, and so the exchange amounts are written from the normalised parameters.

e.g. for process with id 0

|parameter   |  value|
|--------------|--------|
|p_0_production | 4|
|p_1_0  |  3|
|p_2_0  | 1|
|n_p_1_0 | 0.75|
|n_p_2_0 | 0.25|

The production parameters can be edited in the same way as all parameters in the parameters sets tab. They can be used in functions, and they can be assigned by functions too - this is particularly useful for mass balance calculations (e.g. output = sum of all inputs with mass).

Initially merged to the development branch only. Possibly code in a switch (defaulted to off) which retains the old behaviour (force each unit process to describe unitary production) to reduce the complexity of the parameter screen.

