### PR TITLE
build number in recipe must match sed command in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # conda build
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       echo $(date '+%Y%m%d%H%M');
-      sed "s/  number:\ 1/  number:\ $(date '+%Y%m%d%H%M')/g" ./ci/travis/recipe/meta.yaml > /tmp/meta.yaml;
+      sed "s/  number:\ 0/  number:\ $(date '+%Y%m%d%H%M')/g" ./ci/travis/recipe/meta.yaml > /tmp/meta.yaml;
       mv /tmp/meta.yaml ./ci/travis/recipe/meta.yaml;
     fi
   - conda build ./ci/travis/recipe


### PR DESCRIPTION
Hi James,

this is a ridiculously small PR, but hopefully prevents some headache on your side. Glad to see you use my travis-setup with the automatic upload. I think your approach with a dedicated `dev`-branch is even more elegant than what we use for the ActivityBrowser, I thinking about implementing that as well.

This PR fixes a small oversight that i had in my setup:
- The `sed` command in `.travis.yml` overwrites the build number in the conda recipe with the current date, this guarantees that you will always have an increased build number for every new build
- build number in the recipe and travis should both be the same for this to work
- `conda install lcopt-dev` will always get the newest version, even with the same build number because the upload overwrites the previous version
- `conda update lcopt-dev` will however only work with an increase in build number, because otherwise it returns `requirement already satisfied` and won't update