### PR TITLE
use appdirs to store user-generated data like models and config file

### DIFF
--- a/lcopt/data_store.py
+++ b/lcopt/data_store.py
@@ -1,0 +1,41 @@
+import os
+import yaml
+import glob
+
+import appdirs
+
+
+class LcoptStorage():
+    def __init__(self):
+        self.lcopt_dir = appdirs.user_data_dir(
+            appname='Lcopt',
+            appauthor='Lcopt'
+        )
+        if not os.path.isdir(self.lcopt_dir):
+            os.makedirs(self.lcopt_dir)
+
+        # Models
+        self.model_dir = os.path.join(self.lcopt_dir, 'models')
+        if not os.path.isdir(self.model_dir):
+            os.mkdir(self.model_dir)
+
+        # config
+        self.config_file = os.path.join(self.lcopt_dir, 'lcopt_config.yml')
+        if not os.path.exists(self.config_file):
+            with open(self.config_file, 'w') as cfg:
+                cfg.write("")
+
+        self.config = self.load_config()
+
+    def load_config(self):
+        with open(self.config_file, 'r') as cf:
+            config = yaml.load(cf)
+            return config
+
+    @property
+    def models(self):
+        models = glob.glob(os.path.join(self.model_dir, '*.lcopt'))
+        return models
+
+
+storage = LcoptStorage()

--- a/lcopt/model.py
+++ b/lcopt/model.py
@@ -11,6 +11,7 @@ from lcopt.io import *
 from lcopt.interact import FlaskSandbox
 from lcopt.bw2_export import Bw2Exporter
 from lcopt.analysis import Bw2Analysis
+from lcopt.data_store import storage
 from .utils import check_for_config, lcopt_bw2_autosetup, DEFAULT_PROJECT_STEM, bw2_project_exists, write_search_index, FORWAST_PROJECT_NAME, upgrade_old_default, lcopt_bw2_forwast_setup
 # This is a copy straight from bw2data.query, extracted so as not to cause a dependency.
 #from lcopt.bw2query import Query, Dictionaries, Filter
@@ -209,8 +210,13 @@ class LcoptModel(object):
     
     def save(self):
         """save the instance as a .lcopt file"""
-        pickle.dump(self, open("{}.lcopt".format(self.name), "wb"))
-        
+        model_path = os.path.join(
+            storage.model_dir,
+            '{}.lcopt'.format(self.name)
+        )
+        with open(model_path, 'wb') as model_file:
+            pickle.dump(self, model_file)
+
     def load(self, filename):
         """load data from a saved .lcopt file"""
         if filename[-6:] != ".lcopt":

--- a/lcopt/utils.py
+++ b/lcopt/utils.py
@@ -22,6 +22,8 @@ try:
 except:                                                         # pragma: no cover
     raise ImportError('Please install the brightway2 package first')
 
+from lcopt.data_store import storage
+
 DEFAULT_PROJECT_STEM = "LCOPT_Setup_"
 DEFAULT_BIOSPHERE_PROJECT = "LCOPT_Setup_biosphere"
 #DEFAULT_DB_NAME = "LCOPT_Setup"
@@ -80,14 +82,12 @@ def upgrade_old_default():
 def check_for_config():
 
     config = None
-    
-    for loc in os.curdir, os.path.join(os.path.expanduser("~"), "lcopt"), ASSET_PATH:
-        try: 
-            with open(os.path.join(loc,"lcopt_config.yml")) as ymlfile:
-                config = yaml.load(ymlfile)
-                break
-        except IOError:
-            pass
+
+    try:
+        with open(storage.config_file) as config_file:
+            config = yaml.load(config_file)
+    except IOError:
+        pass
 
     return config
 
@@ -159,7 +159,7 @@ def lcopt_bw2_autosetup(ei_username=None, ei_password=None, write_config=None, e
         write_config = input('store username and password on this computer? y/[n]') in ['y', 'Y', 'yes', 'YES', 'Yes']
 
     if write_config:
-        with open(os.path.join(ASSET_PATH, "lcopt_config.yml"), "w") as cfg:
+        with open(storage.config_file, "w") as cfg:
             cfg.write("ecoinvent:\n")
             cfg.write("  username: {}\n".format(ei_username))
             cfg.write("  password: {}\n".format(ei_password))


### PR DESCRIPTION
As discussed in #37, here is how the data storage could look like with appdirs. If you decide to go for this option, I think the clean way would be to store all data generated by lcopt there, like search-indexes etc. Right now lcopt is technically "changing its own source code", since `lcopt/assets` is in the source directory