### PR TITLE
missing module prefix

### DIFF
--- a/lcopt/utils.py
+++ b/lcopt/utils.py
@@ -251,9 +251,9 @@ def lcopt_bw2_forwast_setup(use_autodownload=True, forwast_path=None, db_name=FO
     if storage.project_type  == 'single':
         db_name = storage.single_project_name
         if bw2_project_exists(db_name):
-            projects.set_current(db_name)
+            bw2.projects.set_current(db_name)
         else:
-            projects.set_current(db_name)
+            bw2.projects.set_current(db_name)
             bw2.bw2setup()
 
     else:


### PR DESCRIPTION
```python
In [2]: lcopt.utils.lcopt_bw2_forwast_setup()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-a5ef9122bf69> in <module>()
----> 1 lcopt.utils.lcopt_bw2_forwast_setup()

~/miniconda3/envs/ablcopt/lib/python3.6/site-packages/lcopt/utils.py in lcopt_bw2_forwast_setup(use_autodownload, forwast_path, db_name, overwrite)
    252         db_name = storage.single_project_name
    253         if bw2_project_exists(db_name):
--> 254             projects.set_current(db_name)
    255         else:
    256             projects.set_current(db_name)

NameError: name 'projects' is not defined
```