### PR TITLE
project_exists check missing

### DIFF
--- a/lcopt/model.py
+++ b/lcopt/model.py
@@ -168,8 +168,8 @@ class LcoptModel(object):
 
             self.base_project_name = storage.single_project_name
 
-            #if bw2_project_exists(self.base_project_name):
-            lcopt_bw2_autosetup(ei_username = ei_username, ei_password = ei_password, write_config=write_config, ecoinvent_version=ecoinvent_version, ecoinvent_system_model = ecoinvent_system_model, overwrite=False)
+            if not bw2_project_exists(self.base_project_name):
+                lcopt_bw2_autosetup(ei_username = ei_username, ei_password = ei_password, write_config=write_config, ecoinvent_version=ecoinvent_version, ecoinvent_system_model = ecoinvent_system_model, overwrite=False)
 
         elif not self.useForwast:
 


### PR DESCRIPTION
if you use single storage, it currently runs `lcopt_bw2_autosetup` for every new model created