### PR TITLE
add flask gui to edit lcopt settings

### DIFF
--- a/lcopt/bin/lcopt_settings.py
+++ b/lcopt/bin/lcopt_settings.py
@@ -1,0 +1,7 @@
+from lcopt.settings_gui import settingsGUI
+
+def main():
+	settingsGUI.run()
+
+if __name__ == "__main__":
+    main()

--- a/lcopt/settings.py
+++ b/lcopt/settings.py
@@ -2,6 +2,7 @@ from .data_store import storage
 import yaml
 import types
 
+
 ALLOWED_TYPES = [str, bool, int, float]
 
 class SettingsDict(object):
@@ -63,14 +64,7 @@ class LcoptSettings(object):
 
     def __init__(self, **kwargs):
 
-        self.config = storage.load_config()
-
-        self._sections = []
-
-        for section, content in self.config.items():
-            setattr(self, section, SettingsDict(content, self.write, **kwargs))
-            self._sections.append(section)
-
+        self.refresh(**kwargs)
         self.write() # if floats get conveted to strings during setup, it might auto-overwite with a partial config - this makes sure it doesn't
 
     def as_dict(self):
@@ -90,6 +84,16 @@ class LcoptSettings(object):
 
         return "Lcopt settings: \n\n{}".format(string)
 
+    def refresh(self, **kwargs):
+
+        self.config = storage.load_config()
+
+        self._sections = []
+
+        for section, content in self.config.items():
+            setattr(self, section, SettingsDict(content, self.write, **kwargs))
+            self._sections.append(section)
+
 
     def write(self):
         """write the current settings to the config file"""
@@ -97,5 +101,12 @@ class LcoptSettings(object):
             yaml.dump(self.as_dict(), cfg, default_flow_style=False)
 
         storage.refresh()
+
+    def launch_interact(self):
+        from .settings_gui import FlaskSettingsGUI
+        s = FlaskSettingsGUI()
+        s.run()
+        self.refresh()
+        self.write()
 
 settings = LcoptSettings()

--- a/lcopt/settings_gui.py
+++ b/lcopt/settings_gui.py
@@ -1,0 +1,105 @@
+from flask import Flask, request, render_template, redirect, send_file
+import webbrowser
+import socket
+from .settings import LcoptSettings
+from .constants import DEFAULT_SINGLE_PROJECT
+
+KNOWN_SETTINGS = {
+                    'ecoinvent':['username', 'password', 'version', 'system_model'],
+                    'model_storage': ['location', 'project', 'single_project_name']
+                 }
+
+KNOWN_SETTINGS_META = {
+                        ('ecoinvent', 'username'): {'type':'text', 'label':'username'},
+                        ('ecoinvent', 'password'): {'type': 'password', 'label':'password'},
+                        ('ecoinvent', 'version'): {'type':'select', 'label':'version', 'options':[('3.01', '3.01'),('3.1', '3.1'),('3.2', '3.2'),('3.3', '3.3'),('3.4', '3.4'),]},
+                        ('ecoinvent', 'system_model'): {'type':'select', 'label':'system model', 'options':[('cutoff', 'Cut-off'), ('apos', 'Allocation at the Point of Substitution (APOS)'), ('consequential', 'Consequential')]},
+                        ('model_storage', 'location'): {'type':'select', 'label':'save location', 'options':[('appdir', 'Application directory'), ('curdir', 'Current directory')]},
+                        ('model_storage', 'project'): {'type':'select', 'label':'project setup', 'options':[('single', 'One project containing all lcopt models'), ('unique', 'Each lcopt model has a separate project')]},
+                        ('model_storage', 'single_project_name'): {'type':'text', 'label':'single project name'},
+                      }                
+
+
+
+class FlaskSettingsGUI():
+    
+    def __init__(self):
+        self.settings = LcoptSettings(autowrite=False)
+
+    def shutdown_server(self):                             # pragma: no cover
+        func = request.environ.get('werkzeug.server.shutdown')
+        if func is None:
+            raise RuntimeError('Not running with the Werkzeug Server')
+        func()
+
+    def create_app(self):
+
+        app = Flask(__name__)
+
+        def uc_first(string):
+            return string[0].upper() + string[1:]
+
+        app.jinja_env.filters['uc_first'] = uc_first
+
+        @app.route('/')
+        def index():
+            settings_dict = self.settings.as_dict()
+            if 'single_project_name' not in settings_dict['model_storage'].keys():
+                settings_dict['model_storage']['single_project_name'] = DEFAULT_SINGLE_PROJECT
+
+            args = {
+                    'settings':settings_dict,
+                    'known_settings':KNOWN_SETTINGS,
+                    'known_settings_meta':KNOWN_SETTINGS_META,
+                    }
+            return render_template('lcopt_settings.html', args=args)
+
+
+        @app.route('/shutdown')
+        def shutdown():                             # pragma: no cover
+            self.shutdown_server()
+            return render_template('shutdown.html')
+
+        @app.route('/save_settings', methods=['POST'])
+        def save_settings():
+
+            f = request.form
+
+            for k, v in f.items():
+                section, item = k.split("|")
+                setattr(getattr(self.settings, section), item, v)
+
+            self.settings.write()
+
+            self.shutdown_server()
+            
+            return render_template('settings_saved.html')
+
+        @app.route('/settings_cancel')
+        def cancel_settings():                             # pragma: no cover
+            self.shutdown_server()
+            return render_template('settings_cancel.html')
+
+        return app
+
+    def run(self):                      # pragma: no cover
+        app = self.create_app()
+        
+        for port in range(5000, 5100):
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            result = sock.connect_ex(('127.0.0.1', port))
+            
+            if result != 0:
+                break
+            else:
+                print("port {} is in use, checking {}".format(port, port + 1))
+
+        url = 'http://127.0.0.1:{}/'.format(port)
+        webbrowser.open_new(url)
+        #print ("running from the module")
+        
+        app.run(port=port)
+
+
+settingsGUI = FlaskSettingsGUI()

--- a/lcopt/templates/base.html
+++ b/lcopt/templates/base.html
@@ -70,9 +70,11 @@
 
     <header id="header">
       <nav class="navbar navbar-default nav-top-pad main navbar-static-top">
+        {% block logo %}
         <div class="logo">
           <strong><a href="/" title="LCOPT:Interact"><span class="grey">LCOPT</span><span class="red">Interact</span></a></strong>
         </div>
+        {% endblock %}
         <div class="right">
           <ul class="menu">
             <!--<li class="{% block nav_class_home %}{% endblock %}"><a class="menu-block" href="/">Home</a></li>-->

--- a/lcopt/templates/lcopt_settings.html
+++ b/lcopt/templates/lcopt_settings.html
@@ -1,0 +1,104 @@
+{% extends 'base.html'%}
+
+{% block title %}Settings{% endblock%}
+
+{% block head_postload %}
+    <script src="{{ url_for('static', filename = 'js/cdn_cache/selectize.js') }}"></script>
+    <link rel = "stylesheet" type = "text/css" href = "{{ url_for('static', filename = 'css/cdn_cache/selectize.css') }}" />
+
+{% endblock %}
+
+{% block logo %}
+<div class="logo">
+  <strong><a href="/" title="LCOPT:Settings"><span class="grey">LCOPT</span><span class="red">Settings</span></a></strong>
+</div>
+{% endblock %}
+
+{% block quitbutton %}
+<li class="menu-highlight">
+  <a class="menu-highlight"  href="/settings_cancel">Quit</a>
+</li>
+{% endblock %}
+
+{% block content %}
+
+<div class="container-fluid">
+
+  <div class="row">
+    <div class="col-xs-10 col-xs-offset-1">
+        <form class="form" action="/save_settings" method="post">
+            <div class="row">
+                {% for k, v in args.settings.items()%}
+                <div class="col-xs-6">
+                    <h1>{{k|replace("_", " ")|uc_first}}</h1>
+
+                        {% for ks in args.known_settings[k]%}
+
+                            {% if args.known_settings_meta[(k,ks)]['type']=='text' %}
+                                <div class="form-group" id = "{{k}}|{{ks}}_group">
+                                    <label class="control-label" for="{{k}}|{{ks}}">{{args.known_settings_meta[(k,ks)]['label']|uc_first}}</label>
+                                    <input class="form-control" type="text" name="{{k}}|{{ks}}" id="{{k}}|{{ks}}" value="{{args.settings[k][ks]}}"/>
+                                </div>
+                            {% elif  args.known_settings_meta[(k,ks)]['type']=='password' %}
+                                <div class="form-group" id = "{{k}}|{{ks}}_group">
+                                    <label class="control-label" for="{{k}}|{{ks}}">{{args.known_settings_meta[(k,ks)]['label']|uc_first}}</label>
+                                    <input class="form-control" type="password" name="{{k}}|{{ks}}" id="{{k}}|{{ks}}" value="{{args.settings[k][ks]}}"/>
+                                </div>
+                            {% elif  args.known_settings_meta[(k,ks)]['type']=='select' %}
+                                <div class="form-group" id = "{{k}}|{{ks}}_group">
+                                    <label class="control-label" for="{{k}}|{{ks}}">{{args.known_settings_meta[(k,ks)]['label']|uc_first}}</label>
+                                    <select class="form-control" name="{{k}}|{{ks}}" id="{{k}}|{{ks}}">
+                                        {% for o in args.known_settings_meta[(k,ks)]['options'] %}
+                                            <option value={{o[0]}} {% if o[0] == args.settings[k][ks] %}selected{% endif %}>{{o[1]}}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                            {% endif %}
+
+                        {% endfor%}
+
+
+                        {% for s, t in v.items()%}
+                            {% if s  not in args.known_settings[k] %}
+                                <div class="form-group" id = "{{k}}|{{s}}_group">
+                                    <label class="control-label" for="{{k}}|{{s}}">{{s}}</label>
+                                    <input class="form-control" type="text" name="{{k}}|{{s}}" id="{{k}}|{{s}}" value="{{t}}"/>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+            <div class="row">
+                <div class="col-xs-12">
+                    <input type="submit" class="btn btn-primary" value="Save">
+                    <a href="/settings_cancel" class="btn btn-danger">Cancel</a>
+                </div>
+            </div>
+        </form>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function(){
+
+        check_single = function(){
+            if ($('#model_storage\\|project').val() == 'single'){
+                console.log('single project');
+                $('#model_storage\\|single_project_name_group').show();
+            }else{
+                console.log($('#model_storage\\|project').val());
+                $('#model_storage\\|single_project_name_group').hide();
+            }    
+        }
+
+        $('#model_storage\\|project').change(function(){
+            check_single();            
+        })
+
+        check_single();
+        
+    })
+</script>
+{% endblock %}
+

--- a/lcopt/templates/settings_cancel.html
+++ b/lcopt/templates/settings_cancel.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %} Cancel
+{% endblock %}
+
+{% block logo %}
+<div class="logo">
+  <strong><a href="/" title="LCOPT:Settings"><span class="grey">LCOPT</span><span class="red">Settings</span></a></strong>
+</div>
+{% endblock %}
+
+<!--Overwrite the quit button as blank-->
+{% block quitbutton %}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+	<div class="row">
+	  	<div class="sandboxTitle col-xs-10 col-xs-offset-1">
+			<h2>Canceled - No changes made to settings</h2>
+			<p>You should close this window now... Thanks</p>
+		</div>
+	</div>
+</div>
+
+{% endblock %}

--- a/lcopt/templates/settings_saved.html
+++ b/lcopt/templates/settings_saved.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %} Settings saved
+{% endblock %}
+
+{% block logo %}
+<div class="logo">
+  <strong><a href="/" title="LCOPT:Settings"><span class="grey">LCOPT</span><span class="red">Settings</span></a></strong>
+</div>
+{% endblock %}
+
+<!--Overwrite the quit button as blank-->
+{% block quitbutton %}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+	<div class="row">
+	  	<div class="sandboxTitle col-xs-10 col-xs-offset-1">
+			<h2>Settings saved</h2>
+			<p>You should close this window now... Thanks</p>
+		</div>
+	</div>
+</div>
+
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'lcopt-launcher = lcopt.bin.lcopt_launcher:main',
             'lcopt-bw2-setup = lcopt.bin.lcopt_bw2_setup:main',
             'lcopt-bw2-setup-forwast = lcopt.bin.lcopt_bw2_setup_forwast:main',
+            'lcopt-settings = lcopt.bin.lcopt_settings:main',  
         ]
     },
     #install_requires=[


### PR DESCRIPTION
This PR adds a flask GUI to change lcopt's settings.

It can be accessed from the command line using

```
lcopt-settings
```

or from a notebook using

```python
from lcopt.settings_gui import settingsGUI
settingsGUI.run()
```

It looks like this:

![image](https://user-images.githubusercontent.com/11718809/44217375-9c48d880-a177-11e8-826f-ee4a1850fd2c.png)
