### PR TITLE
find_port utils function, option to not open browser

### DIFF
--- a/lcopt/interact.py
+++ b/lcopt/interact.py
@@ -8,10 +8,10 @@ from itertools import groupby
 import xlsxwriter
 from io import BytesIO
 import os
-import socket
 
 from lcopt.bw2_export import Bw2Exporter
 from lcopt.export_view import LcoptView
+from lcopt.utils import find_port
 
 
 class FlaskSandbox():
@@ -1098,21 +1098,14 @@ class FlaskSandbox():
 
         return app
 
-    def run(self):                      # pragma: no cover
+    def run(self, port=None, open_browser=True):                      # pragma: no cover
         app = self.create_app()
-        
-        for port in range(5000, 5100):
 
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex(('127.0.0.1', port))
-            
-            if result != 0:
-                break
-            else:
-                print("port {} is in use, checking {}".format(port, port + 1))
+        if port is None:
+            port = find_port()
 
-        url = 'http://127.0.0.1:{}/'.format(port)
-        webbrowser.open_new(url)
-        #print ("running from the module")
-        
+        if open_browser:
+            url = 'http://127.0.0.1:{}/'.format(port)
+            webbrowser.open_new(url)
+
         app.run(port=port)

--- a/lcopt/settings_gui.py
+++ b/lcopt/settings_gui.py
@@ -1,8 +1,9 @@
 from flask import Flask, request, render_template, redirect, send_file
 import webbrowser
-import socket
 from .settings import LcoptSettings
 from .constants import DEFAULT_SINGLE_PROJECT
+from .utils import find_port
+
 
 KNOWN_SETTINGS = {
                     'ecoinvent':['username', 'password', 'version', 'system_model'],
@@ -82,23 +83,16 @@ class FlaskSettingsGUI():
 
         return app
 
-    def run(self):                      # pragma: no cover
+    def run(self, port=None, open_browser=True):                      # pragma: no cover
         app = self.create_app()
-        
-        for port in range(5000, 5100):
 
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex(('127.0.0.1', port))
-            
-            if result != 0:
-                break
-            else:
-                print("port {} is in use, checking {}".format(port, port + 1))
+        if port is None:
+            port = find_port()
 
-        url = 'http://127.0.0.1:{}/'.format(port)
-        webbrowser.open_new(url)
-        #print ("running from the module")
-        
+        if open_browser:
+            url = 'http://127.0.0.1:{}/'.format(port)
+            webbrowser.open_new(url)
+
         app.run(port=port)
 
 

--- a/lcopt/utils.py
+++ b/lcopt/utils.py
@@ -16,6 +16,7 @@ from functools import partial
 import yaml
 import pickle
 import getpass
+import socket
 
 try:
     import brightway2 as bw2
@@ -297,3 +298,12 @@ def create_search_index(project_name, ei_name):
     return search_dict
 
 
+def find_port():
+    for port in range(5000, 5100):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = sock.connect_ex(('127.0.0.1', port))
+
+        if result != 0:
+            return port
+        else:
+            print('port {} is in use, checking {}'.format(port, port + 1))


### PR DESCRIPTION
I currently can't access the port number to open the correct url in the AB. This PR makes the "port-finding" a utils function and optionally allows to specify the port and if the browser should be opened as args to the `.run`-methods of the flask apps. Default behaviour isn't changed.