### PR TITLE
Ecoinvent 3.5 compatibility

### DIFF
--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - eidl
     - flask
     - pywin32 # [win]
-    - bw2io =0.6
+    - bw2io >=0.7.1
 
 about:
   home: https://github.com/pjamesjoyce/lcopt/

--- a/lcopt/settings_gui.py
+++ b/lcopt/settings_gui.py
@@ -13,7 +13,7 @@ KNOWN_SETTINGS = {
 KNOWN_SETTINGS_META = {
                         ('ecoinvent', 'username'): {'type':'text', 'label':'username'},
                         ('ecoinvent', 'password'): {'type': 'password', 'label':'password'},
-                        ('ecoinvent', 'version'): {'type':'select', 'label':'version', 'options':[('3.01', '3.01'),('3.1', '3.1'),('3.2', '3.2'),('3.3', '3.3'),('3.4', '3.4'),]},
+                        ('ecoinvent', 'version'): {'type':'select', 'label':'version', 'options':[('3.2', '3.2'),('3.3', '3.3'),('3.4', '3.4'),('3.5', '3.5')]},
                         ('ecoinvent', 'system_model'): {'type':'select', 'label':'system model', 'options':[('cutoff', 'Cut-off'), ('apos', 'Allocation at the Point of Substitution (APOS)'), ('consequential', 'Consequential')]},
                         ('model_storage', 'location'): {'type':'select', 'label':'save location', 'options':[('appdir', 'Application directory'), ('curdir', 'Current directory')]},
                         ('model_storage', 'project'): {'type':'select', 'label':'project setup', 'options':[('single', 'One project containing all lcopt models'), ('unique', 'Each lcopt model has a separate project')]},


### PR DESCRIPTION
two small changes in this PR which are required for ecoinvent 3.5:
- remove the pinned bw2io 0.6 and pin to >=0.7.1 instead, the issue you mentioned in e0800c27e6936e63d630488d305e868a0c4b003e is now resolved and 0.7 is needed to import 3.5 correctly
- update the version options of the settings gui. I also removed ecoivent 3.01 and 3.1 since brightway doesn't support these anymore afaik