### PR TITLE
Reopen the lcopt_setup PR post tests - some fail

### DIFF
--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - eidl
     - flask
     - pywin32 # [win]
-    - bw2io =0.6
+    - bw2io >=0.7.1
 
 about:
   home: https://github.com/pjamesjoyce/lcopt/

--- a/lcopt/model.py
+++ b/lcopt/model.py
@@ -214,13 +214,13 @@ class LcoptModel(object):
 
         elif not self.useForwast:
 
-            self.base_project_name = DEFAULT_PROJECT_STEM + ei_name
+            self.base_project_name = DEFAULT_PROJECT_STEM + self.ecoinventName
             old_default = DEFAULT_PROJECT_STEM[:-1]
             is_default = ecoinvent_version == "3.3" and ecoinvent_system_model == "cutoff"
 
             if bw2_project_exists(self.base_project_name):
                 # make sure the search index file is there too
-                write_search_index(self.base_project_name, ei_name)
+                write_search_index(self.base_project_name, self.ecoinventName)
             elif is_default and bw2_project_exists(old_default):
                 upgrade_old_default()
             else:

--- a/lcopt/settings_gui.py
+++ b/lcopt/settings_gui.py
@@ -13,7 +13,7 @@ KNOWN_SETTINGS = {
 KNOWN_SETTINGS_META = {
                         ('ecoinvent', 'username'): {'type':'text', 'label':'username'},
                         ('ecoinvent', 'password'): {'type': 'password', 'label':'password'},
-                        ('ecoinvent', 'version'): {'type':'select', 'label':'version', 'options':[('3.01', '3.01'),('3.1', '3.1'),('3.2', '3.2'),('3.3', '3.3'),('3.4', '3.4'),]},
+                        ('ecoinvent', 'version'): {'type':'select', 'label':'version', 'options':[('3.2', '3.2'),('3.3', '3.3'),('3.4', '3.4'),('3.5', '3.5')]},
                         ('ecoinvent', 'system_model'): {'type':'select', 'label':'system model', 'options':[('cutoff', 'Cut-off'), ('apos', 'Allocation at the Point of Substitution (APOS)'), ('consequential', 'Consequential')]},
                         ('model_storage', 'location'): {'type':'select', 'label':'save location', 'options':[('appdir', 'Application directory'), ('curdir', 'Current directory')]},
                         ('model_storage', 'project'): {'type':'select', 'label':'project setup', 'options':[('single', 'One project containing all lcopt models'), ('unique', 'Each lcopt model has a separate project')]},


### PR DESCRIPTION
This is a good idea, but there's an issue in the new lcopt_setup function which wasn't picked up because the tests always fail on PRs (#58)- `ei_name` is out of scope